### PR TITLE
add Docker Compose URL for Prowlarr

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -44,7 +44,7 @@ Ygégé peut être utilisé comme indexeur personnalisé pour Prowlarr. Pour le 
 Une fois que c'est fait, redémarrez Prowlarr et allez dans les paramètres des indexeurs, vous devriez voir Ygégé dans la liste des indexeurs disponibles.
 
 > [!NOTE]
-> Prowlarr ne permet pas de personnaliser le "Base URL", par defaut l'url pointe sur `http://localhost:8715/` mais vous pouvez aussi choisir ygege-dns-redirect.local et le rediriger sur l'IP/le domaine de votre choix avec un DNS personnalisé ou en éditant le fichier hosts de votre système.
+> Prowlarr ne permet pas de personnaliser le "Base URL". Par défaut, utilisez `http://localhost:8715/`. Pour les configurations Docker Compose, utilisez `http://ygege:8715/`. Alternativement, utilisez ygege-dns-redirect.local avec un DNS personnalisé ou en éditant le fichier hosts.
 
 ## Contournement Cloudflare
 Pour contourner le défi de Cloudflare, Ygégé n'utilise pas de navigateur ni de services tiers.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Ygégé can be used as a custom indexer for Prowlarr. To set it up, find your Ap
 
 Once it's done, restart Prowlarr and go to the indexer settings, you should see Ygégé in the list of available indexers.
 
-> [!NOTE]  
-> Prowlarr don't allow custom "Base URL", by defaul/t the URL is `http://localhost:8715/` but you can also choose ygege-dns-redirect.local and redirect it on your desired server IP/Domain with custom DNS or by editing you system hosts file
+> [!NOTE]
+> Prowlarr doesn't allow custom "Base URL". By default, use `http://localhost:8715/`. For Docker Compose setups, use `http://ygege:8715/`. Alternatively, use ygege-dns-redirect.local with custom DNS or hosts file redirection.
 
 
 ## Cloudflare Bypass

--- a/ygege.yml
+++ b/ygege.yml
@@ -7,9 +7,9 @@ type: private
 encoding: UTF-8
 links:
   - http://localhost:8715/
+  - http://ygege:8715/
   - http://ygege-dns-redirect.local:8715/
   - https://ygege-dns-redirect.local:8715/
-
 
 ##############################################################################
 # Capacities


### PR DESCRIPTION
  ## Summary
  Adds Docker Compose service URL support for Prowlarr integration.

  ## Changes
  - Added `http://ygege:8715/` to ygege.yml links for Docker service name resolution
  - Updated README.md and README-fr.md to document the Docker Compose URL option

  This allows users running Ygégé and Prowlarr in the same Docker Compose network to use the service name `ygege` instead of `localhost` or custom DNS configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Base URL guidance for Prowlarr: default behavior, explicit Docker Compose URL fallback, and alternative hostname via DNS/hosts, presented as a formatted admonition for clearer user instructions.

* **Chores**
  * Added a new link entry to configuration (http://ygege:8715/) and minor formatting cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->