### PR TITLE
Ajout des options multilang pour remplacer MULTi sur la config prowllarr

### DIFF
--- a/ygege.yml
+++ b/ygege.yml
@@ -106,6 +106,21 @@ settings:
     options:
       asc: Ascendant
       desc: Descendant
+  - name: multilang
+    type: checkbox
+    label: Replace MULTi by another language in release name
+    default: false
+  - name: multilanguage
+    type: select
+    label: Replace MULTi by this language
+    default: FRENCH
+    options:
+      FRENCH: FRENCH
+      MULTi.FRENCH: MULTi.FRENCH
+      ENGLISH: ENGLISH
+      MULTi.ENGLISH: MULTi.ENGLISH
+      VOSTFR: VOSTFR
+      MULTi.VOSTFR: MULTi.VOSTFR
 
 ##############################################################################
 # Search request
@@ -134,7 +149,15 @@ search:
   fields:
     id:       { selector: id }
     category: { selector: category_id }
-    title:    { selector: name }
+    title_normal:
+      selector: name
+    title_multilang:
+      text: "{{ .Result.title_normal }}"
+      filters:
+        - name: re_replace
+          args: ["(?i)[\\.](MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))[\\.]", ".{{ .Config.multilanguage }}."]
+    title:
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_normal }}{{ end }}"
     details:  { selector: download }
     download:
       text: "/torrent/{{ .Result.id }}"


### PR DESCRIPTION
Ajout des options multilang et multilanguage pour l'indexeur Ygégé.

Ça permet de remplacer ".MULTi." par ".FRENCH.", ".VOSTFR." etc. dans les titres des releases. C'est utile pour améliorer le matching sur Radarr/Sonarr.

C'est la même logique/fonctionnalité que sur l'indexeur ygg-api. Aucune dépendance requise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UI settings to configure language preferences for release names.
  * Enabled multilingual support to replace "MULTI" with selected language options in release displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->