### PR TITLE
feat: change details to link for Prowlarr

### DIFF
--- a/ygege.yml
+++ b/ygege.yml
@@ -166,7 +166,7 @@ search:
           args: [ "(?i)(?:[\\.\\s])MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR))(?:[\\.\\s])", ".{{ .Config.multilanguage }}." ]
     title:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_normal }}{{ end }}"
-    details:  { selector: download }
+    details:  { selector: link }
     download:
       text: "/torrent/{{ .Result.id }}"
     seeders:  { selector: seed }


### PR DESCRIPTION
# Description

The link field was added in the /search response, but it's not used by Prowlarr as the definition was not updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated search configuration to use link field for retrieving detail items instead of the previous field source.
  * Added new link field mapping in search settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->