### PR TITLE
Add Nix flake support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1764667669,
+        "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "418468ac9527e799809c900eda37cbff999199b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "Ygégé - Indexeur haute performance pour YGG Torrent";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+      in
+      {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = manifest.name;
+          version = manifest.version;
+
+          # Utilisation de cleanSource pour optimiser le cache
+          src = pkgs.lib.cleanSource ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          nativeBuildInputs = with pkgs; [
+            cmake
+            perl
+            pkg-config
+            git
+            rustPlatform.bindgenHook 
+          ];
+
+          buildInputs = with pkgs; [
+            openssl 
+          ];
+
+          env = {
+            BUILD_COMMIT = self.rev or "dirty";
+            BUILD_DATE = "nix-build";
+            BUILD_BRANCH = "nix";
+          };
+
+          doCheck = false;
+
+          meta = with pkgs.lib; {
+            description = manifest.description or "High-performance indexer for YGG Torrent";
+            homepage = "https://github.com/UwUDev/ygege";
+            license = licenses.mit;
+            mainProgram = "ygege";
+            platforms = platforms.linux;
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${system}.default ];
+          packages = with pkgs; [
+            cargo
+            rustc
+            rust-analyzer
+            clippy
+            rustfmt
+          ];
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,6 @@
           pname = manifest.name;
           version = manifest.version;
 
-          # Utilisation de cleanSource pour optimiser le cache
           src = pkgs.lib.cleanSource ./.;
 
           cargoLock = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Ygégé - Indexeur haute performance pour YGG Torrent";
+  description = "Ygégé - High-performance indexer for YGG Torrent";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";


### PR DESCRIPTION
# Description

This PR adds Nix flake support to enable reproducible builds and easy deployment on NixOS systems. The flake provides a complete build configuration with all necessary dependencies (cmake, OpenSSL, Perl, pkg-config) and proper environment variables for build metadata

## Benefits

- **Reproducible builds**: Guaranteed consistent builds across different machines
- **Easy integration**: Can be directly imported in NixOS configurations
- **Zero-effort dependencies**: All build dependencies are automatically managed by Nix
- **Optimized caching**: Uses `cleanSource` to improve build cache efficiency

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Built successfully with `nix build` on NixOS unstable
- [x] Package can be imported and used in NixOS system configurations
- [x] All native dependencies (cmake, OpenSSL, bindgen) are properly configured
- [x] Build process completes without errors

**Test configuration:**
- OS: NixOS 26.05
- Nix version: 2.x
- System: x86_64-linux

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Notes

The flake is configured with `doCheck = false` to skip tests during Nix builds due to some tests requiring network access or specific runtime conditions. This is a common practice for Nix packages. Local development testing with `cargo test` remains fully functional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Nix flake configuration to enable reproducible per-system Rust builds.
  * Provides a standardized developer shell exposing common Rust tooling (cargo, rustc, rust-analyzer, clippy, rustfmt) for consistent local development and testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->