### PR TITLE
ygg.re redirects to yggtorrent.top which redirects to yggtorrent.org

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -22,12 +22,12 @@ pub async fn get_ygg_domain() -> Result<String, Box<dyn std::error::Error>> {
         .dns_resolver(cloudflare_dns)
         .build()?;
 
-    // get https://ygg.to and get the redirect location domain
+    // get https://www.yggtorrent.org and get the redirect location domain
     debug!("Getting YGG current domain");
 
     let start = std::time::Instant::now();
 
-    let response = client.get("https://ygg.re").send().await?;
+    let response = client.get("https://www.yggtorrent.org").send().await?;
     let location = response
         .headers()
         .get("location")


### PR DESCRIPTION
## 📝 Description

J'ai simplement changé ygg.re pour le nom de domain le plus récent, soit yggtorrent.org

## 🎯 Type de changement

Cochez les options pertinentes :

- [x] 🐛 Bug fix (correction d'un problème sans changement majeur)

## 🔗 Issue liée

Fixes #95

## 🧪 Comment cela a-t-il été testé ?

Décrivez les tests effectués :

- [x] Test A : Ai compilé une nouvelle image Docker avec :  `/usr/bin/docker build -f docker/Dockerfile -t 'ygege' .`  
Cette nouvelle image fonctionne :
```
 INFO  ygege > Ygégé v0.6.1 (commit: unknown, branch: unknown, built: unknown)
 DEBUG ygege::domain > Getting YGG current domain
 DEBUG ygege::domain > Found current YGG domain: www.yggtorrent.org in 181.079695ms
 DEBUG ygege::auth   > Logging in with username: Myself
 DEBUG ygege::auth   > Session is not valid, deleting session file (code 302 Found)
 DEBUG ygege::auth   > Session file deleted
 DEBUG ygege::auth   > Logged in successfully in 703.778391ms
 DEBUG ygege::auth   > Cookies: ygg_=...; account_created=true
 INFO  ygege         > Logged in to YGG with username: Myself
```

**Configuration de test :**
- Docker

## 📋 Checklist

### Code Quality
- [x] Mon code suit les conventions de style du projet
- [x] J'ai effectué une auto-revue de mon code
- [x] J'ai commenté mon code, particulièrement dans les zones difficiles
- [x] Mes changements ne génèrent aucun nouveau warning

### Tests
- [x] Les tests unitaires nouveaux et existants passent localement
- [x] Testé avec Docker
- [x] Testé avec Prowlarr :
```
 DEBUG ygege::rest::search > Received query: q=Le+sapin+a+les+boules&name=Le+sapin+a+les+boules&sort=seed&order=desc&categories=System.Int32%5B%5D
 DEBUG ygege::rest::search > Prowlarr/Jackett detected
 DEBUG ygege::search       > Searching for torrents (name: Some("Le+sapin+a+les+boules"), offset: None, category: None, sub_category: None, sort: Some(Seed), order: Some(Descending))
 DEBUG ygege::search       > Search response: 200 OK
 DEBUG ygege::parser       > detected 6 torrents
 DEBUG ygege::parser       > Parsed 6 torrents
 DEBUG ygege::search       > Found 6 torrents in 223.447344ms
 INFO  ygege::rest::search > 6 torrents found
```

### Dépendances
- [x] Aucune dépendance externe ajoutée sans justification
- [x] Les modifications dépendantes ont été fusionnées/publiées


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated the redirect target domain to the correct URL, ensuring proper redirection functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->