### PR TITLE
feat: add YGG_DOMAIN env var to override auto-detection

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,7 @@ fn load_config_from_env() -> Result<Config, std::io::Error> {
         })?;
 
     let tmdb_token = std::env::var("TMDB_TOKEN").ok();
+    let ygg_domain = std::env::var("YGG_DOMAIN").ok();
 
     Ok(Config {
         username,
@@ -92,6 +93,7 @@ fn load_config_from_env() -> Result<Config, std::io::Error> {
         bind_port,
         log_level,
         tmdb_token,
+        ygg_domain,
     })
 }
 
@@ -104,6 +106,7 @@ pub struct Config {
     #[serde(with = "log_level_serde")]
     pub log_level: LevelFilter,
     pub tmdb_token: Option<String>,
+    pub ygg_domain: Option<String>,
 }
 
 impl Default for Config {
@@ -115,6 +118,7 @@ impl Default for Config {
             bind_port: 8715,
             log_level: LevelFilter::Debug,
             tmdb_token: None,
+            ygg_domain: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,10 +88,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // get the ygg domain
-    let domain = get_ygg_domain().await.unwrap_or_else(|_| {
-        error!("Failed to get YGG domain");
-        std::process::exit(1);
-    });
+    let domain = match &config.ygg_domain {
+        Some(d) => {
+            info!("Using configured YGG domain: {}", d);
+            d.clone()
+        }
+        None => get_ygg_domain().await.unwrap_or_else(|_| {
+            error!("Failed to get YGG domain");
+            std::process::exit(1);
+        }),
+    };
     let mut domain_lock = DOMAIN.lock().unwrap();
     *domain_lock = domain.clone();
     drop(domain_lock);

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -20,7 +20,8 @@ Le fichier de configuration principal est `config.json`. Il doit être placé da
     "bind_ip": "0.0.0.0",
     "bind_port": 8715,
     "log_level": "debug",
-    "tmdb_token": null
+    "tmdb_token": null,
+    "ygg_domain": null
 }
 ```
 
@@ -69,6 +70,19 @@ Lorsque `tmdb_token` est configuré, les résolveurs **TMDB et IMDB** sont autom
 
 Pour configurer TMDB/IMDB, consultez le [guide d'intégration TMDB/IMDB](./tmdb-imdb).
 
+### Configuration du domaine YGG
+
+| Paramètre | Type | Défaut | Description |
+|-----------|------|--------|-------------|
+| `ygg_domain` | string | `null` | Domaine YGG personnalisé (optionnel) |
+
+:::tip Quand utiliser YGG_DOMAIN ?
+Par défaut, Ygégé détecte automatiquement le domaine YGG actuel via une redirection depuis `ygg.re`. Si cette auto-détection échoue (erreurs 307, "Session expired..."), vous pouvez spécifier manuellement le domaine :
+```
+YGG_DOMAIN=www.yggtorrent.org
+```
+:::
+
 ## Variables d'environnement
 
 Toutes les options peuvent également être définies via des variables d'environnement:
@@ -81,6 +95,7 @@ Toutes les options peuvent également être définies via des variables d'enviro
 | `BIND_PORT` | `bind_port` |
 | `LOG_LEVEL` | `log_level` |
 | `TMDB_TOKEN` | `tmdb_token` |
+| `YGG_DOMAIN` | `ygg_domain` |
 
 :::tip Priorité
 Les variables d'environnement ont **priorité** sur le fichier config.json.
@@ -105,6 +120,7 @@ services:
       YGG_PASSWORD: "mon_password"
       LOG_LEVEL: "debug"
       TMDB_TOKEN: "votre_token_tmdb"
+      # YGG_DOMAIN: "www.yggtorrent.org"  # Optionnel : forcer un domaine spécifique
 ```
 
 ### Pour fichier config.json
@@ -116,7 +132,8 @@ services:
     "bind_ip": "0.0.0.0",
     "bind_port": 8715,
     "log_level": "debug",
-    "tmdb_token": "votre_token_tmdb"
+    "tmdb_token": "votre_token_tmdb",
+    "ygg_domain": null
 }
 ```
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/configuration.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/configuration.md
@@ -20,7 +20,8 @@ The main configuration file is `config.json`. It should be placed in the `/confi
     "bind_ip": "0.0.0.0",
     "bind_port": 8715,
     "log_level": "debug",
-    "tmdb_token": null
+    "tmdb_token": null,
+    "ygg_domain": null
 }
 ```
 
@@ -61,7 +62,20 @@ Available levels:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `tmdb_api_key` | string | `""` | TMDB API key (optional) |
+| `tmdb_token` | string | `null` | TMDB API key (optional) |
+
+### YGG Domain Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ygg_domain` | string | `null` | Custom YGG domain (optional) |
+
+:::tip When to use YGG_DOMAIN?
+By default, Ygégé automatically detects the current YGG domain via a redirect from `ygg.re`. If this auto-detection fails (307 errors, "Session expired..."), you can manually specify the domain:
+```
+YGG_DOMAIN=www.yggtorrent.org
+```
+:::
 
 ## Environment Variables
 
@@ -75,6 +89,7 @@ All options can also be set via environment variables:
 | `BIND_PORT` | `bind_port` |
 | `LOG_LEVEL` | `log_level` |
 | `TMDB_TOKEN` | `tmdb_token` |
+| `YGG_DOMAIN` | `ygg_domain` |
 
 :::tip Priority
 Environment variables have **priority** over config.json file.
@@ -99,6 +114,7 @@ services:
       YGG_PASSWORD: "my_password"
       LOG_LEVEL: "info"
       TMDB_TOKEN: "your_tmdb_token"
+      # YGG_DOMAIN: "www.yggtorrent.org"  # Optional: force a specific domain
 ```
 
 ### For config.json File
@@ -110,7 +126,8 @@ services:
     "bind_ip": "0.0.0.0",
     "bind_port": 8715,
     "log_level": "debug",
-    "tmdb_token": "your_tmdb_token"
+    "tmdb_token": "your_tmdb_token",
+    "ygg_domain": null
 }
 ```
 


### PR DESCRIPTION
## 📝 Description

Ajout d'une variable d'environnement `YGG_DOMAIN` optionnelle permettant de spécifier manuellement le domaine YGG pour contourner la 301 actuelle et ne plus avoir ce problème dans le futur.

**Problème :** L'auto-détection via `ygg.re` redirige vers l'ancien domaine (`yggtorrent.top`) au lieu du nouveau (`yggtorrent.org`), causant des erreurs 301, 307 Temporary Redirect et "Session expired...".

**Solution :** Quand `YGG_DOMAIN` est défini, le domaine configuré est utilisé directement sans passer par l'auto-détection.

**Utilisation :**
```yaml
environment:
  - YGG_DOMAIN=www.yggtorrent.org
```

## 🎯 Type de changement

Cochez les options pertinentes :

- [x] 🐛 Bug fix (correction d'un problème sans changement majeur)
- [x] ✨ Nouvelle fonctionnalité (ajout de fonctionnalité sans changement majeur)
- [ ] 💥 Breaking change (correction ou fonctionnalité qui casse la compatibilité)
- [ ] 📚 Documentation (mise à jour de la documentation uniquement)
- [ ] 🔧 Configuration / CI/CD (changements de configuration ou workflows)
- [ ] ♻️ Refactoring (changements qui n'ajoutent pas de fonctionnalité ni ne corrigent de bugs)
- [ ] ⚡ Performance (amélioration des performances)

## 🔗 Issue liée

Fixes #94
Fixes #95

## 🧪 Comment cela a-t-il été testé ?

Décrivez les tests effectués :

- [x] Test A : Build Docker réussi avec la nouvelle option
- [x] Test B : Vérification que la variable `YGG_DOMAIN` est correctement lue depuis l'environnement

**Configuration de test :**
- OS : Arch Linux (CachyOS 6.17.7)
- Version Rust : 1.92
- Runtime : Docker

## 📸 Captures d'écran (si applicable)

N/A - Changement backend uniquement

## 📋 Checklist

### Code Quality
- [x] Mon code suit les conventions de style du projet
- [x] J'ai effectué une auto-revue de mon code
- [x] J'ai commenté mon code, particulièrement dans les zones difficiles
- [x] Mes changements ne génèrent aucun nouveau warning

### Documentation
- [ ] J'ai mis à jour la documentation correspondante (FR & EN si applicable)
- [ ] Si API modifiée : `docs/api-documentation.md` et `docs/api-documentation-fr.md` mis à jour
- [ ] Si configuration modifiée : exemples dans `docs/` mis à jour

### Tests
- [ ] J'ai ajouté des tests prouvant l'efficacité de mon correctif/fonctionnalité
- [x] Les tests unitaires nouveaux et existants passent localement
- [x] Testé avec Docker (si applicable)
- [ ] Testé avec Prowlarr/Radarr/Sonarr (si applicable)

### Dépendances
- [x] Aucune dépendance externe ajoutée sans justification
- [x] Les modifications dépendantes ont été fusionnées/publiées

## 🔄 Changements majeurs (si applicable)

Aucun breaking change. La fonctionnalité est entièrement optionnelle et rétrocompatible.

### Migration requise

Aucune migration requise. Pour utiliser la nouvelle fonctionnalité, ajoutez simplement :
```yaml
environment:
  - YGG_DOMAIN=www.yggtorrent.org
```

## 📌 Notes supplémentaires

Cette PR permet aux utilisateurs de contourner le problème d'auto-détection en attendant que `ygg.re` redirige correctement vers le nouveau domaine. La fonctionnalité reste optionnelle : si `YGG_DOMAIN` n'est pas défini, le comportement actuel (auto-détection) est conservé.

---

**Note pour les reviewers :**
- Les modifications sont minimales et localisées dans `src/config.rs` et `src/main.rs`
- La documentation pourrait être mise à jour pour mentionner cette nouvelle variable d'environnement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add optional YGG domain configuration via environment variable; when set, the app uses it directly (no runtime resolution) and logs that configured value.
  * Default remains unset/null when not provided.

* **Documentation**
  * Docs and examples updated to document YGG_DOMAIN, config sample, and Docker Compose usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->