### PR TITLE
Modification du lien .top en .org

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -27,7 +27,7 @@ pub async fn get_ygg_domain() -> Result<String, Box<dyn std::error::Error>> {
 
     let start = std::time::Instant::now();
 
-    let response = client.get("https://ygg.re").send().await?;
+    let response = client.get("https://yggtorrent.org").send().await?;
     let location = response
         .headers()
         .get("location")


### PR DESCRIPTION
En executant docker compose, le lien en .top crashé l'identifiant. J'ai modifié en .org. j'ai rebuild le dockerfile avec `docker build -t ygege-new_domain -f docker/Dockerfile .` et ça fonctionne depuis
