### PR TITLE
fix(dbs): validate TMDB/IMDB IDs before building API URLs

### DIFF
--- a/src/dbs.rs
+++ b/src/dbs.rs
@@ -103,6 +103,17 @@ pub async fn get_queries(
     db_type: DbQueryType,
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     debug!("Fetching TMDB titles for ID: {}", id);
+
+    let is_valid_id = match db_type {
+        DbQueryType::TMDB => id.chars().all(|c| c.is_ascii_digit()),
+        DbQueryType::IMDB => {
+            id.starts_with("tt") && id[2..].chars().all(|c| c.is_ascii_digit())
+        }
+    };
+    if !is_valid_id {
+        return Err(format!("Invalid database ID: {}", id).into());
+    }
+
     let client = Client::new();
     let url = match db_type {
         DbQueryType::TMDB => format!("https://api.themoviedb.org/3/movie/{}", id),


### PR DESCRIPTION
## Summary

TMDB and IMDB IDs from query parameters (`tmdbid`, `imdbid`) are interpolated directly into API URLs without any validation. This allows path traversal and query injection:

```
GET /search?tmdbid=../../3/configuration?api_key=xxx
```

This resolves to `https://api.themoviedb.org/3/configuration?api_key=xxx` instead of `/3/movie/...`, leaking the configured Bearer token to unintended TMDB endpoints.

## Fix

Validates that TMDB IDs are digits-only and IMDB IDs match the `tt{digits}` format before building the URL.

## Test plan

- [x] `tmdbid=../../3/configuration` → rejected with `Invalid database ID`
- [x] `tmdbid=550?api_key=xxx` → rejected
- [x] `imdbid=../../3/configuration` → rejected
- [x] `tmdbid=550` → works normally
- [x] `imdbid=tt0137523` → works normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented input validation for database identifiers to detect invalid formats before processing requests. Invalid identifiers now trigger clear error messages with specific format requirements, improving user feedback and system reliability when working with database queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->